### PR TITLE
test: add integration tests for both validator controllers

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ env:
 
 jobs:
   test-unit:
-    name: Run Unit Tests
+    name: Run Unit & Integration Tests
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4
@@ -27,7 +27,7 @@ jobs:
           go-version: ${{ env.GO_VERSION }}
 
       - name: Test
-        run: go test -v ./...
+        run: make test
 
   test-chart:
     name: Run Helm Chart Tests

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run tests
+name: Run Unit & Integration Tests
 
 on:
   push:
@@ -15,7 +15,7 @@ env:
     GO_VERSION: "~1.20"
 
 jobs:
-  test-unit:
+  test:
     name: Run Unit & Integration Tests
     runs-on: ubuntu-latest
     steps:
@@ -25,6 +25,9 @@ jobs:
         uses: actions/setup-go@93397bea11091df50f3d7e59dc26a7711a8bcfbe # v4
         with:
           go-version: ${{ env.GO_VERSION }}
+
+      - name: Set up Helm
+        run: make helm
 
       - name: Test
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -1,4 +1,4 @@
-name: Run Unit & Integration Tests
+name: Test
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -21,7 +21,8 @@ Dockerfile.cross
 # editor and IDE paraphernalia
 .devspace
 .idea
-.vscode
+.vscode/
+!.vscode/launch.json
 *.swp
 *.swo
 *~

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,36 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Devspace",
+            "type": "go",
+            "request": "attach",
+            "mode": "remote",
+            "port": 2342,
+            "host": "127.0.0.1",
+            "substitutePath": [
+                {
+                  "from": "${workspaceFolder}",
+                  "to": "/workspace",
+                },
+              ],
+              "showLog": true,
+              "trace": "verbose", // use for debugging problems with delve (breakpoints not working, etc.)
+        },
+        {
+          "name": "Test Integration",
+          "type": "go",
+          "request": "launch",
+          "mode": "test",
+          "program": "${workspaceFolder}/internal/controller",
+          "env": {
+              "KUBECONFIG": "/Users/tylergillson/Downloads/testkind.kubeconfig",
+              // "KUBECONFIG": "",
+              "KUBEBUILDER_ASSETS": "/Users/tylergillson/spectrocloud/repos/oss/spectrocloud-labs/validation/validator/bin/k8s/1.27.1-darwin-arm64"
+          }
+      },
+    ]
+}

--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	k8s.io/client-go v0.28.3
 	k8s.io/klog/v2 v2.110.1
 	sigs.k8s.io/controller-runtime v0.16.3
+	sigs.k8s.io/yaml v1.3.0
 )
 
 require (
@@ -71,5 +72,4 @@ require (
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2 // indirect
 	sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd // indirect
 	sigs.k8s.io/structured-merge-diff/v4 v4.2.3 // indirect
-	sigs.k8s.io/yaml v1.3.0 // indirect
 )

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -164,6 +164,11 @@ var _ = AfterSuite(func() {
 	err := k8sClient.Delete(ctx, validatorNs)
 	Expect(err).ToNot(HaveOccurred(), "failed to tear down the validator namespace")
 	Eventually(func() bool {
+		// Skip namespace teardown if running in EnvTest
+		// https://book.kubebuilder.io/reference/envtest.html#namespace-usage-limitation
+		if os.Getenv("KUBECONFIG") == "" {
+			return true
+		}
 		err := k8sClient.Get(ctx, validatorNsKey, validatorNs)
 		return apierrs.IsNotFound(err)
 	}, 1*time.Minute, interval).Should(BeTrue(), "failed to tear down the validator namespace")

--- a/internal/controller/suite_test.go
+++ b/internal/controller/suite_test.go
@@ -166,7 +166,7 @@ var _ = AfterSuite(func() {
 	Eventually(func() bool {
 		err := k8sClient.Get(ctx, validatorNsKey, validatorNs)
 		return apierrs.IsNotFound(err)
-	}, timeout, interval).Should(BeTrue(), "failed to tear down the validator namespace")
+	}, 1*time.Minute, interval).Should(BeTrue(), "failed to tear down the validator namespace")
 
 	By("tearing down the test environment")
 	cancel()

--- a/internal/controller/testdata/vc-network.yaml
+++ b/internal/controller/testdata/vc-network.yaml
@@ -1,0 +1,69 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: ValidatorConfig
+metadata:
+  annotations:
+    meta.helm.sh/release-name: validator
+    meta.helm.sh/release-namespace: validator
+  labels:
+    app.kubernetes.io/managed-by: Helm
+  name: validator-config
+  namespace: validator
+spec:
+  plugins:
+  - chart:
+      name: validator-plugin-network
+      repository: https://spectrocloud-labs.github.io/validator-plugin-network
+      version: v0.0.4
+    values: |-
+      controllerManager:
+        kubeRbacProxy:
+          args:
+          - --secure-listen-address=0.0.0.0:8443
+          - --upstream=http://127.0.0.1:8080/
+          - --logtostderr=true
+          - --v=0
+          containerSecurityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          image:
+            repository: gcr.io/kubebuilder/kube-rbac-proxy
+            tag: v0.14.1
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 5m
+              memory: 64Mi
+        manager:
+          args:
+          - --health-probe-bind-address=:8081
+          - --leader-elect
+          containerSecurityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+              - ALL
+          image:
+            repository: quay.io/spectrocloud-labs/validator-plugin-network
+            tag: v0.0.4
+          resources:
+            limits:
+              cpu: 500m
+              memory: 128Mi
+            requests:
+              cpu: 10m
+              memory: 64Mi
+        replicas: 1
+        serviceAccount:
+          annotations: {}
+      kubernetesClusterDomain: cluster.local
+      metricsService:
+        ports:
+        - name: https
+          port: 8443
+          protocol: TCP
+          targetPort: https
+        type: ClusterIP

--- a/internal/controller/testdata/vc-network.yaml
+++ b/internal/controller/testdata/vc-network.yaml
@@ -6,7 +6,7 @@ metadata:
     meta.helm.sh/release-namespace: validator
   labels:
     app.kubernetes.io/managed-by: Helm
-  name: validator-config
+  name: validator-config-test
   namespace: validator
 spec:
   plugins:

--- a/internal/controller/testdata/vr-aws-service-quota.yaml
+++ b/internal/controller/testdata/vr-aws-service-quota.yaml
@@ -1,0 +1,56 @@
+apiVersion: validation.spectrocloud.labs/v1alpha1
+kind: ValidationResult
+metadata:
+  name: validator-plugin-aws-service-quota
+spec:
+  expectedResults: 4
+  plugin: AWS
+status:
+  conditions:
+  - details:
+    - 'EC2-VPC Elastic IPs: quota: 5, buffer: 1, max. usage: 3, max. usage entity:
+      us-east-2'
+    - 'Public AMIs: quota: 5, buffer: 1, max. usage: 0, max. usage entity: us-east-2'
+    lastValidationTime: "2023-11-10T16:24:21Z"
+    message: Usage for all service quotas is below specified buffer
+    status: "True"
+    validationRule: validation-ec2
+    validationType: aws-service-quota
+  - details:
+    - 'File systems per account: quota: 1000, buffer: 4, max. usage: 0, max. usage
+      entity: us-east-2'
+    lastValidationTime: "2023-11-10T16:24:24Z"
+    message: Usage for all service quotas is below specified buffer
+    status: "True"
+    validationRule: validation-elasticfilesystem
+    validationType: aws-service-quota
+  - details:
+    - 'Application Load Balancers per Region: quota: 50, buffer: 5, max. usage: 0,
+      max. usage entity: us-east-2'
+    - 'Classic Load Balancers per Region: quota: 20, buffer: 4, max. usage: 3, max.
+      usage entity: us-east-2'
+    - 'Network Load Balancers per Region: quota: 50, buffer: 5, max. usage: 0, max.
+      usage entity: us-east-2'
+    lastValidationTime: "2023-11-10T16:24:25Z"
+    message: Usage for all service quotas is below specified buffer
+    status: "True"
+    validationRule: validation-elasticloadbalancing
+    validationType: aws-service-quota
+  - details:
+    - 'Subnets per VPC: quota: 200, buffer: 5, max. usage: 6, max. usage entity: vpc-00288d3415348f34c'
+    - 'NAT gateways per Availability Zone: quota: 5, buffer: 30, max. usage: 1, max.
+      usage entity: us-east-2a'
+    - 'Network interfaces per Region: quota: 5000, buffer: 6, max. usage: 18, max.
+      usage entity: us-east-2'
+    - 'Internet gateways per Region: quota: 5, buffer: 1, max. usage: 3, max. usage
+      entity: us-east-2'
+    failures:
+    - Remaining quota 4, less than buffer 30, for service vpc and quota NAT gateways
+      per Availability Zone
+    lastValidationTime: "2023-11-10T16:24:26Z"
+    message: Usage for one or more service quotas exceeded the specified buffer
+    status: "False"
+    validationRule: validation-vpc
+    validationType: aws-service-quota
+  sinkState: Succeeded
+  state: Failed

--- a/internal/controller/validationresult_controller.go
+++ b/internal/controller/validationresult_controller.go
@@ -102,6 +102,7 @@ func (r *ValidationResultReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// emissions will occur during the 1st reconciliation, where N is the number of rules in the validator.
 		if vc.Spec.Sink != nil && len(vr.Status.Conditions) == vr.Spec.ExpectedResults && (!ok || prevHash != currHash) {
 			sinkState = v1alpha1.SinkEmitFailed
+			vr.Status.SinkState = sinkState
 
 			sink := sinks.NewSink(vc.Spec.Sink.Type, r.Log)
 

--- a/internal/controller/validationresult_controller.go
+++ b/internal/controller/validationresult_controller.go
@@ -30,6 +30,7 @@ import (
 
 	v1alpha1 "github.com/spectrocloud-labs/validator/api/v1alpha1"
 	"github.com/spectrocloud-labs/validator/internal/sinks"
+	"github.com/spectrocloud-labs/validator/pkg/constants"
 )
 
 // ValidationResultHash is used to determine whether to re-emit updates to a validation result sink.
@@ -52,7 +53,7 @@ func (r *ValidationResultReconciler) Reconcile(ctx context.Context, req ctrl.Req
 	r.Log.V(0).Info("Reconciling ValidationResult", "name", req.Name, "namespace", req.Namespace)
 
 	vc := &v1alpha1.ValidatorConfig{}
-	vcKey := types.NamespacedName{Namespace: r.Namespace, Name: "validator-config"}
+	vcKey := types.NamespacedName{Namespace: r.Namespace, Name: constants.ValidatorConfig}
 	if err := r.Get(ctx, vcKey, vc); err != nil {
 		// ignore not-found errors, since they can't be fixed by an immediate requeue
 		if apierrs.IsNotFound(err) {

--- a/internal/controller/validationresult_controller_test.go
+++ b/internal/controller/validationresult_controller_test.go
@@ -1,0 +1,101 @@
+package controller
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	kyaml "sigs.k8s.io/yaml"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+
+	"github.com/spectrocloud-labs/validator/api/v1alpha1"
+	//+kubebuilder:scaffold:imports
+)
+
+const (
+	validationResultName = "validator-plugin-aws-service-quota"
+)
+
+var (
+	vrServiceQuota = filepath.Join("testdata", "vr-aws-service-quota.yaml")
+)
+
+var _ = Describe("ValidationResult controller", Ordered, func() {
+	vc := &v1alpha1.ValidatorConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      validatorConfigName,
+			Namespace: validatorNamespace,
+		},
+		Spec: v1alpha1.ValidatorConfigSpec{
+			Sink: &v1alpha1.Sink{
+				Type:       "slack",
+				SecretName: "slack-secret",
+			},
+		},
+	}
+
+	vr := &v1alpha1.ValidationResult{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      validationResultName,
+			Namespace: validatorNamespace,
+		},
+		Spec: v1alpha1.ValidationResultSpec{
+			Plugin:          "AWS",
+			ExpectedResults: 4,
+		},
+	}
+	vrKey := types.NamespacedName{Name: validationResultName, Namespace: validatorNamespace}
+
+	It("Should hash the ValidationResult and update its Status once a ValidationResult is created", func() {
+		By("By creating a new ValidationResult")
+		ctx := context.Background()
+
+		Expect(k8sClient.Create(ctx, vc)).Should(Succeed())
+		Expect(k8sClient.Create(ctx, vr)).Should(Succeed())
+
+		Expect(k8sClient.Get(ctx, vrKey, vr)).Should(Succeed())
+		vr.Status.State = v1alpha1.ValidationInProgress
+		Expect(k8sClient.Status().Update(ctx, vr)).Should(Succeed())
+
+		// Wait for the ValidationResult's Status to be updated
+		Eventually(func() bool {
+			if err := k8sClient.Get(ctx, vrKey, vr); err != nil {
+				return false
+			}
+			stateOk := vr.Status.State == v1alpha1.ValidationInProgress
+			sinkStateOk := vr.Status.SinkState == v1alpha1.SinkEmitNone
+			hashOk := vr.ObjectMeta.Annotations[ValidationResultHash] == vr.Hash()
+			return stateOk && sinkStateOk && hashOk
+		}, timeout, interval).Should(BeTrue(), "failed to update ValidationResult Status")
+	})
+
+	It("Should attempt to emit a message to Slack once the ValidationResult is updated", func() {
+		By("By updating the ValidationResult")
+		ctx := context.Background()
+
+		vrBytes, err := os.ReadFile(vrServiceQuota)
+		Expect(err).NotTo(HaveOccurred())
+
+		vrUpdated := &v1alpha1.ValidationResult{}
+		err = kyaml.Unmarshal(vrBytes, vrUpdated)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Get(ctx, vrKey, vr)).Should(Succeed())
+		vr.Status = vrUpdated.Status
+		Expect(k8sClient.Status().Update(ctx, vr)).Should(Succeed())
+
+		// Wait for the ValidationResult's Status to be updated
+		Eventually(func() bool {
+			if err := k8sClient.Get(ctx, vrKey, vr); err != nil {
+				return false
+			}
+			// expect the sink to fail, as we've not created the slack secret
+			sinkStateOk := vr.Status.SinkState == v1alpha1.SinkEmitFailed
+			return sinkStateOk
+		}, timeout, interval).Should(BeTrue(), "failed to update ValidationResult Status")
+	})
+})

--- a/internal/controller/validationresult_controller_test.go
+++ b/internal/controller/validationresult_controller_test.go
@@ -13,6 +13,7 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 
 	"github.com/spectrocloud-labs/validator/api/v1alpha1"
+	"github.com/spectrocloud-labs/validator/pkg/constants"
 	//+kubebuilder:scaffold:imports
 )
 
@@ -25,9 +26,17 @@ var (
 )
 
 var _ = Describe("ValidationResult controller", Ordered, func() {
+
+	BeforeEach(func() {
+		// toggle true/false to enable/disable the ValidationResult controller specs
+		if false {
+			Skip("skipping")
+		}
+	})
+
 	vc := &v1alpha1.ValidatorConfig{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      validatorConfigName,
+			Name:      constants.ValidatorConfig,
 			Namespace: validatorNamespace,
 		},
 		Spec: v1alpha1.ValidatorConfigSpec{

--- a/internal/controller/validatorconfig_controller_test.go
+++ b/internal/controller/validatorconfig_controller_test.go
@@ -24,7 +24,6 @@ const (
 	networkPluginDeploymentImage = "quay.io/spectrocloud-labs/validator-plugin-network"
 	networkPluginVersionPre      = "v0.0.4"
 	networkPluginVersionPost     = "v0.0.5"
-	validatorConfigName          = "validator-config"
 )
 
 var (
@@ -34,15 +33,16 @@ var (
 )
 
 var _ = Describe("ValidatorConfig controller", Ordered, func() {
+
 	BeforeEach(func() {
-		// comment in or out to disable the ValidatorConfig controller specs
-		if true {
+		// toggle true/false to enable/disable the ValidatorConfig controller specs
+		if false {
 			Skip("skipping")
 		}
 	})
 
 	vc := &v1alpha1.ValidatorConfig{}
-	vcKey := types.NamespacedName{Name: validatorConfigName, Namespace: validatorNamespace}
+	vcKey := types.NamespacedName{Name: "validator-config-test", Namespace: validatorNamespace}
 	networkPluginDeploymentKey := types.NamespacedName{Name: networkPluginDeploymentName, Namespace: validatorNamespace}
 	networkPluginDeployment := &appsv1.Deployment{}
 

--- a/internal/controller/validatorconfig_controller_test.go
+++ b/internal/controller/validatorconfig_controller_test.go
@@ -1,0 +1,108 @@
+package controller
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+
+	appsv1 "k8s.io/api/apps/v1"
+	apierrs "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	kyaml "sigs.k8s.io/yaml"
+
+	"github.com/spectrocloud-labs/validator/api/v1alpha1"
+	//+kubebuilder:scaffold:imports
+)
+
+const (
+	networkPluginDeploymentName  = "validator-plugin-network-controller-manager"
+	networkPluginDeploymentImage = "quay.io/spectrocloud-labs/validator-plugin-network"
+	networkPluginVersionPre      = "v0.0.4"
+	networkPluginVersionPost     = "v0.0.5"
+	validatorConfigName          = "validator-config"
+)
+
+var (
+	vcNetwork         = filepath.Join("testdata", "vc-network.yaml")
+	expectedImagePre  = fmt.Sprintf("%s:%s", networkPluginDeploymentImage, networkPluginVersionPre)
+	expectedImagePost = fmt.Sprintf("%s:%s", networkPluginDeploymentImage, networkPluginVersionPost)
+)
+
+var _ = Describe("ValidatorConfig controller", Ordered, func() {
+	BeforeEach(func() {
+		// comment in or out to disable the ValidatorConfig controller specs
+		if true {
+			Skip("skipping")
+		}
+	})
+
+	vc := &v1alpha1.ValidatorConfig{}
+	vcKey := types.NamespacedName{Name: validatorConfigName, Namespace: validatorNamespace}
+	networkPluginDeploymentKey := types.NamespacedName{Name: networkPluginDeploymentName, Namespace: validatorNamespace}
+	networkPluginDeployment := &appsv1.Deployment{}
+
+	It("Should deploy validator-plugin-network once a ValidatorConfig is created", func() {
+		By("By creating a new ValidatorConfig")
+		ctx := context.Background()
+
+		vcBytes, err := os.ReadFile(vcNetwork)
+		Expect(err).NotTo(HaveOccurred())
+
+		err = kyaml.Unmarshal(vcBytes, vc)
+		Expect(err).NotTo(HaveOccurred())
+
+		Expect(k8sClient.Create(ctx, vc)).Should(Succeed())
+
+		// Wait for the validator-plugin-network Deployment to be deployed
+		Eventually(func() bool {
+			if err := k8sClient.Get(ctx, networkPluginDeploymentKey, networkPluginDeployment); err != nil {
+				return false
+			}
+			imageOk := networkPluginDeployment.Spec.Template.Spec.Containers[1].Image == expectedImagePre
+			healthy := networkPluginDeployment.Status.ReadyReplicas == networkPluginDeployment.Status.Replicas
+			return imageOk && healthy
+		}, timeout, interval).Should(BeTrue(), "failed to deploy validator-plugin-network")
+	})
+
+	It("Should upgrade validator-plugin-network once the ValidatorConfig is updated", func() {
+		By("Updating the ValidatorConfig")
+		ctx := context.Background()
+
+		Expect(k8sClient.Get(ctx, vcKey, vc)).Should(Succeed())
+
+		vc.Spec.Plugins[0].Chart.Version = networkPluginVersionPost
+		vc.Spec.Plugins[0].Values = strings.ReplaceAll(
+			vc.Spec.Plugins[0].Values, networkPluginVersionPre, networkPluginVersionPost,
+		)
+
+		Expect(k8sClient.Update(ctx, vc)).Should(Succeed())
+
+		// Wait for the validator-plugin-network Deployment to be upgraded
+		Eventually(func() bool {
+			if err := k8sClient.Get(ctx, networkPluginDeploymentKey, networkPluginDeployment); err != nil {
+				return false
+			}
+			imageOk := networkPluginDeployment.Spec.Template.Spec.Containers[1].Image == expectedImagePost
+			healthy := networkPluginDeployment.Status.ReadyReplicas == networkPluginDeployment.Status.Replicas
+			return imageOk && healthy
+		}, timeout, interval).Should(BeTrue(), "failed to upgrade validator-plugin-network")
+	})
+
+	It("Should uninstall validator-plugin-network once the ValidatorConfig is deleted", func() {
+		By("Deleting the ValidatorConfig")
+		ctx := context.Background()
+
+		Expect(k8sClient.Delete(ctx, vc)).Should(Succeed())
+
+		// Wait for validator-plugin-network Deployment to be deleted
+		Eventually(func() bool {
+			err := k8sClient.Get(ctx, networkPluginDeploymentKey, networkPluginDeployment)
+			return apierrs.IsNotFound(err)
+		}, timeout, interval).Should(BeTrue(), "failed to uninstall validator-plugin-network")
+	})
+})

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -1,3 +1,6 @@
 package constants
 
-const ValidationRulePrefix string = "validation"
+const (
+	ValidationRulePrefix string = "validation"
+	ValidatorConfig      string = "validator-config"
+)


### PR DESCRIPTION
Testing:
- Add integration tests for `ValidationResult` and `ValidatorConfig` controllers
- Fix GitHub action to setup and run integration tests properly

Bug Fixes:
- Ensure `ValidationResult.Status` updates succeed reliably
- Ensure `ValidationResult.Status.SinkState` is always marked failed if the sink configuration is invalid
