### PR TITLE
fix: omit secret data from ValidatorConfig

### DIFF
--- a/chart/validator/templates/plugin-secret-aws.yaml
+++ b/chart/validator/templates/plugin-secret-aws.yaml
@@ -1,0 +1,14 @@
+{{- if .Values.pluginSecrets.aws }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ required ".Values.pluginSecrets.aws.secretName is required!" .Values.pluginSecrets.aws.secretName }}
+stringData:
+  credentials: |
+    [default]
+    aws_access_key_id={{ required ".Values.pluginSecrets.aws.accessKeyId is required!" .Values.pluginSecrets.aws.accessKeyId }}
+    aws_secret_access_key={{ required ".Values.pluginSecrets.aws.secretAccessKey is required!" .Values.pluginSecrets.aws.secretAccessKey }}
+    {{- if .Values.pluginSecrets.aws.sessionToken }}
+    aws_session_token={{ $.Values.pluginSecrets.aws.sessionToken }}
+    {{- end }}
+{{- end }}

--- a/chart/validator/templates/plugin-secret-vsphere.yaml
+++ b/chart/validator/templates/plugin-secret-vsphere.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.pluginSecrets.vSphere }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ required ".Values.pluginSecrets.vSphere.secretName is required!" .Values.pluginSecrets.vSphere.secretName }}
+data:
+  username: {{ required ".Values.pluginSecrets.vSphere.username is required!" .Values.pluginSecrets.vSphere.username | b64enc }}
+  password: {{ required ".Values.pluginSecrets.vSphere.password is required!" .Values.pluginSecrets.vSphere.password | b64enc }}
+  vcenterServer: {{ required ".Values.pluginSecrets.vSphere.vcenterServer is required!" .Values.pluginSecrets.vSphere.vcenterServer | b64enc }}
+  insecureSkipVerify: {{ required ".Values.pluginSecrets.vSphere.insecureSkipVerify is required!" .Values.pluginSecrets.vSphere.insecureSkipVerify | b64enc }}
+{{- end }}

--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -265,7 +265,7 @@ pluginSecrets:
   # If installing the AWS plugin, the below config is required unless one of the following applies:
   # - the target cluster already has a secret with the correct format and you've specified its name above
   # - you're deploying to a K8s cluster in AWS and relying on an node instance IAM role
-  # - you're deploying to an K8s cluster in AWS and relying on IMDSv2, plus you've specified auth.serviceAccountName
+  # - you're deploying to a K8s cluster in AWS and relying on IMDSv2, plus you've specified auth.serviceAccountName
   aws: {}
     # secretName: aws-creds  # ensure this matches the AWS plugin values above
     # accessKeyId: ""

--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -77,7 +77,7 @@ plugins:
 - chart:
     name: validator-plugin-aws
     repository: "https://spectrocloud-labs.github.io/validator-plugin-aws"
-    version: "v0.0.10"
+    version: "v0.0.16"
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -112,7 +112,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/spectrocloud-labs/validator-plugin-aws
-          tag: v0.0.8
+          tag: v0.0.16
         resources:
           limits:
             cpu: 500m
@@ -134,21 +134,16 @@ plugins:
     auth:
       # Leave secret undefined for implicit auth (node instance role, IMDSv2, etc.)
       secret: {}
+        # If creating a secret via pluginSecrets (see below), uncomment the following two lines.
         # secretName: aws-creds
-        # accessKeyId: ""
-        # secretAccessKey: ""
-        # sessionToken: ""
-        # By default, a secret will be created. Leave the above fields blank and specify 'createSecret: false' to use an existing secret.
-        # WARNING: the existing secret must match the format used in auth-secret.yaml
-        # createSecret: true
-
+        # createSecret: false  # leave this false (the validator-plugin-aws chart doesn't need to create the secret)
       # Override the service account used by AWS validator (optional, could be used for IMDSv2 on EKS)
       # WARNING: the chosen service account must have the same RBAC privileges as seen in manager-rbac.yaml
       serviceAccountName: ""
 - chart:
     name: validator-plugin-vsphere
     repository: "https://spectrocloud-labs.github.io/validator-plugin-vsphere"
-    version: "v0.0.12"
+    version: "v0.0.13"
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -183,7 +178,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/spectrocloud-labs/validator-plugin-vsphere
-          tag: v0.0.11
+          tag: v0.0.13
         resources:
           limits:
             cpu: 500m
@@ -203,15 +198,14 @@ plugins:
         targetPort: https
       type: ClusterIP
     auth:
+      # If creating a secret via pluginSecrets (see below), the secret names must match. Alternatively,
+      # leave the pluginSecrets section undefined and specify the name of a preexisting secret in your target cluster.
       secretName: vsphere-creds
-      username: ""
-      password: ""
-      vcenterServer: ""
-      insecureSkipVerify: ""
+      createSecret: false  # leave this false (the validator-plugin-vsphere chart doesn't need to create the secret)
 - chart:
     name: validator-plugin-network
     repository: "https://spectrocloud-labs.github.io/validator-plugin-network"
-    version: "v0.0.4"
+    version: "v0.0.7"
   values: |-
     controllerManager:
       kubeRbacProxy:
@@ -248,7 +242,7 @@ plugins:
             - ALL
         image:
           repository: quay.io/spectrocloud-labs/validator-plugin-network
-          tag: v0.0.4
+          tag: v0.0.7
         resources:
           limits:
             cpu: 500m
@@ -267,3 +261,22 @@ plugins:
         protocol: TCP
         targetPort: https
       type: ClusterIP
+pluginSecrets:
+  # If installing the AWS plugin, the below config is required unless one of the following applies:
+  # - the target cluster already has a secret with the correct format and you've specified its name above
+  # - you're deploying to a K8s cluster in AWS and relying on an node instance IAM role
+  # - you're deploying to an K8s cluster in AWS and relying on IMDSv2, plus you've specified auth.serviceAccountName
+  aws: {}
+    # secretName: aws-creds  # ensure this matches the AWS plugin values above
+    # accessKeyId: ""
+    # secretAccessKey: ""
+    # sessionToken: ""
+
+  # If installing the vSphere plugin, the below config is required unless the following applies:
+  # - the target cluster already has a secret with the correct format and you've specified its name above
+  vSphere: {}
+    # secretName: vsphere-creds  # ensure this matches the vSphere plugin values above
+    # username: ""
+    # password: ""
+    # vcenterServer: ""
+    # insecureSkipVerify: ""

--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -134,7 +134,9 @@ plugins:
     auth:
       # Leave secret undefined for implicit auth (node instance role, IMDSv2, etc.)
       secret: {}
-        # If creating a secret via pluginSecrets (see below), uncomment the following line (and delete the curly braces on the line above).
+        # If creating a secret via pluginSecrets (see below), uncomment secretName and delete the curly braces on the line above;
+        # ensuring that secretName and pluginSecrets.aws.secretName match. Alternatively, leave pluginSecrets.aws undefined and
+        # specify the name of a preexisting secret in your target cluster.
         # secretName: aws-creds
       # Override the service account used by AWS validator (optional, could be used for IMDSv2 on EKS)
       # WARNING: the chosen service account must have the same RBAC privileges as seen in manager-rbac.yaml
@@ -197,8 +199,8 @@ plugins:
         targetPort: https
       type: ClusterIP
     auth:
-      # If creating a secret via pluginSecrets (see below), the secret names must match. Alternatively,
-      # leave pluginSecrets.vSphere undefined and specify the name of a preexisting secret in your target cluster.
+      # If creating a secret via pluginSecrets (see below), secretName and pluginSecrets.vSphere.secretName must match.
+      # Alternatively, leave pluginSecrets.vSphere undefined and specify the name of a preexisting secret in your target cluster.
       secretName: vsphere-creds
 - chart:
     name: validator-plugin-network

--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -134,9 +134,8 @@ plugins:
     auth:
       # Leave secret undefined for implicit auth (node instance role, IMDSv2, etc.)
       secret: {}
-        # If creating a secret via pluginSecrets (see below), uncomment the following two lines.
+        # If creating a secret via pluginSecrets (see below), uncomment the following line (and delete the curly braces on the line above).
         # secretName: aws-creds
-        # createSecret: false  # leave this false (the validator-plugin-aws chart doesn't need to create the secret)
       # Override the service account used by AWS validator (optional, could be used for IMDSv2 on EKS)
       # WARNING: the chosen service account must have the same RBAC privileges as seen in manager-rbac.yaml
       serviceAccountName: ""
@@ -199,9 +198,8 @@ plugins:
       type: ClusterIP
     auth:
       # If creating a secret via pluginSecrets (see below), the secret names must match. Alternatively,
-      # leave the pluginSecrets section undefined and specify the name of a preexisting secret in your target cluster.
+      # leave pluginSecrets.vSphere undefined and specify the name of a preexisting secret in your target cluster.
       secretName: vsphere-creds
-      createSecret: false  # leave this false (the validator-plugin-vsphere chart doesn't need to create the secret)
 - chart:
     name: validator-plugin-network
     repository: "https://spectrocloud-labs.github.io/validator-plugin-network"


### PR DESCRIPTION
The top-level validator chart cannot include sensitive data for plugin credentials in the ValidatorConfig. Therefore we need to pre-create the necessary secrets in the parent chart. 