### PR TITLE
feat: add OCI plugin

### DIFF
--- a/chart/validator/templates/plugin-secret-oci.yaml
+++ b/chart/validator/templates/plugin-secret-oci.yaml
@@ -1,0 +1,10 @@
+{{- range .Values.pluginSecrets.oci }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ required ".Values.pluginSecrets.oci.secretName is required!" .secretName }}
+stringData:
+  username: {{ required ".Values.pluginSecrets.oci.username is required!" .username }}
+  password: {{ required ".Values.pluginSecrets.oci.password is required!" .password }}
+---
+{{- end }}

--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -471,6 +471,11 @@ pluginSecrets:
     # vcenterServer: ""
     # insecureSkipVerify: ""
 
+  # If installing the OCI plugin and validating against private registries, the below config is required unless the following applies:
+  # - The target cluster already contains secrets with the correct format for all private registries.
+  #   If specifying your own secret, refer to chart/validator/templates/plugin-secret-oci.yaml for
+  #   an example of the expected format and ensure that it exists in the same namespace as the Helm release.
+  #
   oci: []  # Don't forget to delete these square brackets if you're specifying credentials here!
     # - secretName: registry-creds # ensure this matches the secretName in the OciRegistryRule
     #   username: username # for ECR Registries, store the AWS_ACCESS_KEY_ID here

--- a/chart/validator/values.yaml
+++ b/chart/validator/values.yaml
@@ -71,7 +71,11 @@ proxy:
   secretName: proxy-cert
   # If false (using an existing secret), the key whose value is the CA certificate must end with '.crt'.
   createSecret: false
-  caCert: ""  # Raw CA certificate, required if createSecret is true
+  # Raw CA certificate, required if createSecret is true
+  caCert: |
+    -----BEGIN CERTIFICATE-----
+    <your certificate content here>
+    -----END CERTIFICATE-----
 
 # Optional sink configuration
 sink: {}
@@ -359,6 +363,63 @@ plugins:
         protocol: TCP
         targetPort: https
       type: ClusterIP
+- chart:
+    name: validator-plugin-oci
+    repository: "https://spectrocloud-labs.github.io/validator-plugin-oci"
+    version: v0.0.2
+  values: |-
+    controllerManager:
+      kubeRbacProxy:
+        args:
+        - --secure-listen-address=0.0.0.0:8443
+        - --upstream=http://127.0.0.1:8080/
+        - --logtostderr=true
+        - --v=0
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        image:
+          repository: gcr.io/kubebuilder/kube-rbac-proxy
+          tag: v0.15.0
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 5m
+            memory: 64Mi
+      manager:
+        args:
+        - --health-probe-bind-address=:8081
+        - --leader-elect
+        containerSecurityContext:
+          allowPrivilegeEscalation: false
+          capabilities:
+            drop:
+            - ALL
+        image:
+          repository: quay.io/spectrocloud-labs/validator-plugin-oci
+          tag: v0.0.2
+        resources:
+          limits:
+            cpu: 500m
+            memory: 128Mi
+          requests:
+            cpu: 10m
+            memory: 64Mi
+      replicas: 1
+      serviceAccount:
+        annotations: {}
+    kubernetesClusterDomain: cluster.local
+    metricsService:
+      ports:
+      - name: https
+        port: 8443
+        protocol: TCP
+        targetPort: https
+      type: ClusterIP
 
 pluginSecrets:
   # If installing the AWS plugin, the below config is required unless one of the following applies:
@@ -409,3 +470,8 @@ pluginSecrets:
     # password: ""
     # vcenterServer: ""
     # insecureSkipVerify: ""
+
+  oci: []  # Don't forget to delete these square brackets if you're specifying credentials here!
+    # - secretName: registry-creds # ensure this matches the secretName in the OciRegistryRule
+    #   username: username # for ECR Registries, store the AWS_ACCESS_KEY_ID here
+    #   password: pa$$w0rd # for ECR Registries, store the AWS_SECRET_ACCESS_KEY here


### PR DESCRIPTION
This PR adds the OCI validator plugin to the validator

The following cases were also manually tested and confirmed to be working as expected:
- Creating credentials for multiple oci registries
- Loading a custom proxy certificate