### PR TITLE
fix: dynamically set cleanup wait time

### DIFF
--- a/chart/validator/templates/cleanup.yaml
+++ b/chart/validator/templates/cleanup.yaml
@@ -95,7 +95,7 @@ spec:
         command: ["/cleanup"]
         env:
         - name: CLEANUP_DELAY_SECONDS
-          value: "10"
+          value: {{ mul 10 (max 1 (len (required ".Values.plugins is required!" .Values.plugins))) | quote }}
         resources:
           requests:
             cpu: "10m"


### PR DESCRIPTION
After a lot of testing i noticed that at the high end, it takes a little under 10 seconds to delete each plugin thats added. This is mostly due to the synchronous portion of the deletePlugin function. To combat this, we can dynamically set the wait time to `10 * len(plugins)`. This will ensure we wont have long wait times when a user only adds a couple plugins.