### PR TITLE
fix: use http to make request to gRPC server

### DIFF
--- a/internal/controller/validatorconfig_controller.go
+++ b/internal/controller/validatorconfig_controller.go
@@ -406,7 +406,7 @@ func (r *ValidatorConfigReconciler) emitFinalizeCleanup() error {
 		return fmt.Errorf("CLEANUP_GRPC_SERVER_PORT is invalid: %w", err)
 	}
 
-	url := fmt.Sprintf("https://%s:%s", host, port)
+	url := fmt.Sprintf("http://%s:%s", host, port)
 	client := cleanupv1connect.NewCleanupServiceClient(
 		http.DefaultClient,
 		url,

--- a/internal/controller/validatorconfig_controller_test.go
+++ b/internal/controller/validatorconfig_controller_test.go
@@ -266,7 +266,7 @@ func TestEmitFinalizeCleanup(t *testing.T) {
 				"CLEANUP_GRPC_SERVER_HOST":    "localhost",
 				"CLEANUP_GRPC_SERVER_PORT":    "1234",
 			},
-			expected: errors.New(`FinalizeCleanup request to https://localhost:1234 failed: unavailable: dial tcp [::1]:1234: connect: connection refused`),
+			expected: errors.New(`FinalizeCleanup request to http://localhost:1234 failed: unavailable: dial tcp [::1]:1234: connect: connection refused`),
 		},
 	}
 	for _, c := range cs {


### PR DESCRIPTION
Addresses this error encountered during tests:
```
ERROR    controllers.ValidatorConfig    Failed to emit FinalizeCleanup request    {"error": "FinalizeCleanup request to https://validator-cleanup-service:3006 failed: unavailable: http: server gave HTTP response to HTTPS client"}
```