### PR TITLE
fix: support empty proxy caCert values

### DIFF
--- a/chart/validator/templates/proxy-secret.yaml
+++ b/chart/validator/templates/proxy-secret.yaml
@@ -5,5 +5,5 @@ metadata:
   name: {{ required ".Values.proxy.secretName is required!" .Values.proxy.secretName }}
 stringData:
   ca.crt: |
-{{ required ".Values.proxy.caCert is required!" .Values.proxy.caCert | indent 4 }}
+{{ .Values.proxy.caCert | indent 4 }}
 {{- end }}


### PR DESCRIPTION
Previously, using this valid snippet of the values.yaml:
```
proxy:
  enabled: true
  image: quay.io/spectrocloud-labs/validator-certs-init:latest
  secretName: proxy-cert
  createSecret: true
  caCert: ""
```
would result in the following error:
```
Error: INSTALLATION FAILED: execution error at (validator/templates/proxy-secret.yaml:8:3): .Values.proxy.caCert is required!
```

Now, we'll be able to create a secret with no caCert